### PR TITLE
Fix retrieval spelling in messages

### DIFF
--- a/R/viz_bp.R
+++ b/R/viz_bp.R
@@ -116,7 +116,7 @@ viz_bp <- function(startseason, endseason = NULL, lg = "all", bat_metric = "wOBA
       highcharter::hc_subtitle(text = paste0(x, " Season")) |>
       # # adding credits and date when the chart was build
       highcharter::hc_credits(enabled = TRUE,
-                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
                                             lubridate::with_tz(Sys.time(), "US/Eastern")  |>
                                               format("%Y-%m-%d %H:%M %Z")))  |>
       # enable exporting option
@@ -193,7 +193,7 @@ viz_bp <- function(startseason, endseason = NULL, lg = "all", bat_metric = "wOBA
  #    ggplot2::labs(
  #      title = "MLB Teams wRC+ vs. ERA-",
  #      subtitle = paste0(season_data$Season[1], " Season"),
- #      caption = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+ #      caption = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
  #                       lubridate::with_tz(Sys.time(), "US/Eastern")))
  #
  # } )

--- a/R/viz_rd.R
+++ b/R/viz_rd.R
@@ -51,7 +51,7 @@ viz_rd <- function(team, year) {
   if (intersect(grepl("AL|NL", team),
                 grepl("East|Central|West|Overall", team))) {
     # Division or leagues in that year
-    message(paste0("Retreiving teams that played in ", team, " in ", year, "..."))
+    message(paste0("Retrieving teams that played in ", team, " in ", year, "..."))
     teams <- baseballr::bref_standings_on_date(paste0(year,"-04-30"), team) |>
       as.data.frame() |>
       select(1) |>
@@ -62,7 +62,7 @@ viz_rd <- function(team, year) {
     # All MLB teams in year
     mlb <- c("AL Overall", "NL Overall")
 
-    message(paste0("Retreiving teams that played in ", team, " in ", year, "..."))
+    message(paste0("Retrieving teams that played in ", team, " in ", year, "..."))
     teams <- pbapply::pbsapply(mlb, baseballr::bref_standings_on_date, date = paste0(year,"-04-30"))
     teams <- c(teams[[1,1]], teams[[1,2]])
 
@@ -251,7 +251,7 @@ viz_rd <- function(team, year) {
                                  })  |>
       # adding credits and date when the chart was build
       highcharter::hc_credits(enabled = TRUE,
-                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
                                             with_tz(Sys.time(), "US/Eastern")  |>
                                               format("%Y-%m-%d %H:%M %Z")))  |>
       # enable exporting option

--- a/R/viz_rd_team.R
+++ b/R/viz_rd_team.R
@@ -184,7 +184,7 @@ viz_rd_team <- function(team, start_year, end_year, highlight_year = NULL) {
     highcharter::hc_subtitle(text = paste("Between ", start_year, " and", end_year, ", highlighting the ", highlight_year, "season."))  |>
     ## Adding notes in the bottom of  the chart
     highcharter::hc_credits(enabled = TRUE,                          # add credits
-                            text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+                            text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
                                           with_tz(Sys.time(), "US/Eastern")  |>
                                             format("%Y-%m-%d %H:%M %Z")))  |>
     ## Enabling the menu to export the charts

--- a/R/viz_rd_wpct.R
+++ b/R/viz_rd_wpct.R
@@ -51,7 +51,7 @@ viz_rd_wpct <- function(team, year) {
   if (intersect(grepl("AL|NL", team),
                 grepl("East|Central|West|Overall", team))) {
     # Division or leagues in that year
-    message(paste0("Retreiving teams that played in ", team, " in ", year, "..."))
+    message(paste0("Retrieving teams that played in ", team, " in ", year, "..."))
     teams <- baseballr::bref_standings_on_date(paste0(year,"-04-30"), team) |>
       as.data.frame() |>
       select(1) |>
@@ -62,7 +62,7 @@ viz_rd_wpct <- function(team, year) {
     # All MLB teams in year
     mlb <- c("AL Overall", "NL Overall")
 
-    message(paste0("Retreiving teams that played in ", team, " in ", year, "..."))
+    message(paste0("Retrieving teams that played in ", team, " in ", year, "..."))
     teams <- pbapply::pbsapply(mlb, baseballr::bref_standings_on_date, date = paste0(year,"-04-30"))
     teams <- c(teams[[1,1]], teams[[1,2]])
 
@@ -266,7 +266,7 @@ viz_rd_wpct <- function(team, year) {
                                  })  |>
       # adding credits and date when the chart was build
       highcharter::hc_credits(enabled = TRUE,
-                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
                                             with_tz(Sys.time(), "US/Eastern")  |>
                                               format("%Y-%m-%d %H:%M %Z")))  |>
       # enable exporting option

--- a/R/viz_streak.R
+++ b/R/viz_streak.R
@@ -25,7 +25,7 @@ viz_streak <- function(team, year) {
   if (intersect(grepl("AL|NL", team),
                 grepl("East|Central|West|Overall", team))) {
     # Division or leagues in that year
-    message(paste0("Retreiving teams that played in ", team, " in ", year, "..."))
+    message(paste0("Retrieving teams that played in ", team, " in ", year, "..."))
     teams <- baseballr::bref_standings_on_date(paste0(year,"-04-30"), team) |>
       as.data.frame() |>
       select(1) |>
@@ -36,7 +36,7 @@ viz_streak <- function(team, year) {
     # All MLB teams in year
     mlb <- c("AL Overall", "NL Overall")
 
-    message(paste0("Retreiving teams that played in ", team, " in ", year, "..."))
+    message(paste0("Retrieving teams that played in ", team, " in ", year, "..."))
     teams <- pbapply::pbsapply(mlb, baseballr::bref_standings_on_date, date = paste0(year,"-04-30"))
     teams <- c(teams[[1,1]], teams[[1,2]])
 
@@ -220,7 +220,7 @@ viz_streak <- function(team, year) {
                                  })  |>
       # adding credits and date when the chart was build
       highcharter::hc_credits(enabled = TRUE,
-                              text = paste0("Source: Baseball Reference. Using 'bbgraphsR' R package. Retreived on: ",
+                              text = paste0("Source: Baseball Reference. Using 'bbgraphsR' R package. Retrieved on: ",
                                             lubridate::with_tz(Sys.time(), "US/Eastern")  |>
                                               format("%Y-%m-%d %H:%M %Z")))  |>
       # enable exporting option

--- a/R/viz_wlp_season.R
+++ b/R/viz_wlp_season.R
@@ -37,14 +37,14 @@ viz_wlp_season <- function(lg_div, year) {
   if (intersect(grepl("AL|NL", lg_div),
                 grepl("East|Central|West|Overall", lg_div))) {
     # Division or leagues in that year
-    message(paste0("Retreiving teams that played in ", lg_div, " in ", year, "..."))
+    message(paste0("Retrieving teams that played in ", lg_div, " in ", year, "..."))
     teams <- baseballr::bref_standings_on_date(paste0(year,"-04-30"), lg_div) |>
       as.data.frame() |>
       dplyr::select(1) |>
       unlist()
 
   } else if (lg_div == "MLB") {
-    message(paste0("Retreiving teams that played in ", lg_div, " in ", year, "..."))
+    message(paste0("Retrieving teams that played in ", lg_div, " in ", year, "..."))
     teams_al <- baseballr::bref_standings_on_date(paste0(year,"-04-30"), "AL Overall")
     teams_nl <- baseballr::bref_standings_on_date(paste0(year,"-04-30"), "NL Overall")
     teams <- rbind(teams_al, teams_nl) |>
@@ -236,7 +236,7 @@ viz_wlp_season <- function(lg_div, year) {
     ) |>
     highcharter::hc_subtitle(text =  "Solid line(s) represent the Division(s) leader(s)") |>
     highcharter::hc_credits(enabled = TRUE,
-                            text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+                            text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
                                           lubridate::with_tz(Sys.time(), "US/Eastern")  |>
                                             format("%Y-%m-%d %H:%M %Z")))  |>
     highcharter::hc_add_theme(highcharter::hc_theme_smpl()) |>

--- a/R/viz_wlp_years.R
+++ b/R/viz_wlp_years.R
@@ -403,7 +403,7 @@ viz_wlp_years <- function(from_season, until_season = from_season + 1, league = 
         paste("W% in Reg. season (" , min(wl$Season), "-", max(wl$Season), "): <strong><span style='color: ", font_color, ";'>", teams_data$Wp_global[1]), "</span></strong> (", wl_whole$W, "-", wl_whole$L, ")")) |>
       # # adding credits and date when the chart was build
       highcharter::hc_credits(enabled = TRUE,
-                              text = paste0("Source: Fangraph. Using 'bbraphsR' package. Retreived on: ",
+                              text = paste0("Source: Fangraph. Using 'bbraphsR' package. Retrieved on: ",
                                             lubridate::with_tz(Sys.time(), "US/Eastern") |>
                                               format("%Y-%m-%d %H:%M %Z"))) |>
       # enable exporting option


### PR DESCRIPTION
## Summary
- correct typo "Retreived" → "Retrieved"
- correct typo "Retreiving" → "Retrieving"

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843115f0be0832e881e8ce5b5efbcbd