### PR TITLE
Fix seasons initialization in viz_bp

### DIFF
--- a/R/viz_bp.R
+++ b/R/viz_bp.R
@@ -9,9 +9,7 @@
 viz_bp <- function(startseason, endseason = NULL, lg = "all", bat_metric = "wOBA", pit_metric = "ERA") {
 
   if (is.null(endseason)) {
-
-    until_season <- from_season # meaning just 1 season will be retrieved
-
+    seasons <- startseason
   } else {
     seasons <- seq(startseason, endseason, by = 1)
   }


### PR DESCRIPTION
## Summary
- fix conditional seasons logic when `endseason` is `NULL`
- remove unused variables

## Testing
- `R CMD build .` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431296a410832e806ec803fb62f2e2