### PR TITLE
Fix credits text and typos

### DIFF
--- a/R/viz_bp.R
+++ b/R/viz_bp.R
@@ -116,7 +116,7 @@ viz_bp <- function(startseason, endseason = NULL, lg = "all", bat_metric = "wOBA
       highcharter::hc_subtitle(text = paste0(x, " Season")) |>
       # # adding credits and date when the chart was build
       highcharter::hc_credits(enabled = TRUE,
-                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
                                             lubridate::with_tz(Sys.time(), "US/Eastern")  |>
                                               format("%Y-%m-%d %H:%M %Z")))  |>
       # enable exporting option
@@ -193,8 +193,8 @@ viz_bp <- function(startseason, endseason = NULL, lg = "all", bat_metric = "wOBA
  #    ggplot2::labs(
  #      title = "MLB Teams wRC+ vs. ERA-",
  #      subtitle = paste0(season_data$Season[1], " Season"),
- #      caption = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
- #                       lubridate::with_tz(Sys.time(), "US/Eastern")))
+#      caption = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
+#                       lubridate::with_tz(Sys.time(), "US/Eastern")))
  #
  # } )
  #

--- a/R/viz_rd.R
+++ b/R/viz_rd.R
@@ -251,7 +251,7 @@ viz_rd <- function(team, year) {
                                  })  |>
       # adding credits and date when the chart was build
       highcharter::hc_credits(enabled = TRUE,
-                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
                                             with_tz(Sys.time(), "US/Eastern")  |>
                                               format("%Y-%m-%d %H:%M %Z")))  |>
       # enable exporting option

--- a/R/viz_rd_team.R
+++ b/R/viz_rd_team.R
@@ -184,7 +184,7 @@ viz_rd_team <- function(team, start_year, end_year, highlight_year = NULL) {
     highcharter::hc_subtitle(text = paste("Between ", start_year, " and", end_year, ", highlighting the ", highlight_year, "season."))  |>
     ## Adding notes in the bottom of  the chart
     highcharter::hc_credits(enabled = TRUE,                          # add credits
-                            text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+                            text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
                                           with_tz(Sys.time(), "US/Eastern")  |>
                                             format("%Y-%m-%d %H:%M %Z")))  |>
     ## Enabling the menu to export the charts

--- a/R/viz_rd_wpct.R
+++ b/R/viz_rd_wpct.R
@@ -266,7 +266,7 @@ viz_rd_wpct <- function(team, year) {
                                  })  |>
       # adding credits and date when the chart was build
       highcharter::hc_credits(enabled = TRUE,
-                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+                              text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
                                             with_tz(Sys.time(), "US/Eastern")  |>
                                               format("%Y-%m-%d %H:%M %Z")))  |>
       # enable exporting option

--- a/R/viz_streak.R
+++ b/R/viz_streak.R
@@ -220,7 +220,7 @@ viz_streak <- function(team, year) {
                                  })  |>
       # adding credits and date when the chart was build
       highcharter::hc_credits(enabled = TRUE,
-                              text = paste0("Source: Baseball Reference. Using 'bbgraphsR' R package. Retreived on: ",
+                              text = paste0("Source: Baseball Reference. Using 'bbgraphsR' R package. Retrieved on: ",
                                             lubridate::with_tz(Sys.time(), "US/Eastern")  |>
                                               format("%Y-%m-%d %H:%M %Z")))  |>
       # enable exporting option

--- a/R/viz_wlp_season.R
+++ b/R/viz_wlp_season.R
@@ -236,7 +236,7 @@ viz_wlp_season <- function(lg_div, year) {
     ) |>
     highcharter::hc_subtitle(text =  "Solid line(s) represent the Division(s) leader(s)") |>
     highcharter::hc_credits(enabled = TRUE,
-                            text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retreived on: ",
+                            text = paste0("Source: Baseball Reference. Using 'baseballr' R package. Retrieved on: ",
                                           lubridate::with_tz(Sys.time(), "US/Eastern")  |>
                                             format("%Y-%m-%d %H:%M %Z")))  |>
     highcharter::hc_add_theme(highcharter::hc_theme_smpl()) |>

--- a/R/viz_wlp_years.R
+++ b/R/viz_wlp_years.R
@@ -403,7 +403,7 @@ viz_wlp_years <- function(from_season, until_season = from_season + 1, league = 
         paste("W% in Reg. season (" , min(wl$Season), "-", max(wl$Season), "): <strong><span style='color: ", font_color, ";'>", teams_data$Wp_global[1]), "</span></strong> (", wl_whole$W, "-", wl_whole$L, ")")) |>
       # # adding credits and date when the chart was build
       highcharter::hc_credits(enabled = TRUE,
-                              text = paste0("Source: Fangraph. Using 'bbraphsR' package. Retreived on: ",
+                              text = paste0("Source: FanGraphs. Using 'bbgraphsR' package. Retrieved on: ",
                                             lubridate::with_tz(Sys.time(), "US/Eastern") |>
                                               format("%Y-%m-%d %H:%M %Z"))) |>
       # enable exporting option


### PR DESCRIPTION
## Summary
- correct credit text in `viz_wlp_years` to reference FanGraphs and bbgraphsR
- fix spelling of 'Retrieved' across visualization scripts

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684314cd1268832e96d4c6137035f6e7