### PR TITLE
Add viz_rd invalid team test

### DIFF
--- a/tests/testthat/test-viz_rd.R
+++ b/tests/testthat/test-viz_rd.R
@@ -1,0 +1,7 @@
+context("viz_rd")
+
+library(bbgraphsR)
+
+test_that("viz_rd errors with invalid team", {
+  expect_error(viz_rd("XYZ", 2021))
+})


### PR DESCRIPTION
## Summary
- add a new test file for `viz_rd`
- confirm an invalid team abbreviation triggers an error

## Testing
- `R -q -e 'testthat::test_check("bbgraphsR")'` *(fails: `bash: R: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684315a46c94832eb15191d4f1d221d6